### PR TITLE
Add sort common files script and CLI option for create app

### DIFF
--- a/.github/workflows/create-app.yml
+++ b/.github/workflows/create-app.yml
@@ -129,6 +129,8 @@ jobs:
           fi
 
       - name: Create PR
+        # an error here most likely means PR already exists, so we let it pass
+        continue-on-error: true
         working-directory: ./repo
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/create-app.yml
+++ b/.github/workflows/create-app.yml
@@ -6,9 +6,13 @@ on:
         required: true
         description: "Name of the application (ex. 'react')"
         type: string
+      package:
+        default: ''
+        description: "Package to install for CLI (ex. 'gatsby-cli')"
+        type: string
       command:
         required: true
-        description: "Base create command (ex. 'react-app')"
+        description: "Base create command (ex. 'react-app' or 'gatsby init')"
         type: string
       type:
         required: true
@@ -22,6 +26,10 @@ on:
         default: ''
         description: "Color to apply to GitHub label (ex. 'E99695')"
         type: string
+      create_dir:
+        default: true
+        description: "Should the 'jam-app' dir be created first in the CLI implementation"
+        type: boolean
 
 jobs:
   create_app:
@@ -36,14 +44,28 @@ jobs:
           fetch-depth: '0'
           path: repo
 
+      - name: Setup node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
       - name: Create app folder
         run: |
           sudo mkdir app
 
-      - name: Run create command
+      - if: inputs.package == ''
+        name: Run create command
         working-directory: ./app
         run: |
-          sudo yarn create ${{ inputs.command }} jam-app ${{ inputs.flags }}
+          sudo npx create-${{ inputs.command }} jam-app ${{ inputs.flags }}
+
+      - if: inputs.package
+        name: Create with CLI
+        working-directory: ./app
+        run: |
+          sudo npm install -g ${{ inputs.package }}
+          [ "${{ inputs.create_dir }}" = true ] && sudo mkdir jam-app
+          sudo ${{ inputs.command }} jam-app ${{ inputs.flags }}
 
         # delete extra files and add empty lock file to prevent workspace install
       - name: Clean up app
@@ -97,6 +119,15 @@ jobs:
           git commit -m 'Update templates/${{ inputs.name }}/${{ inputs.type }}'
           git push origin template/${{ inputs.name }}
 
+      - name: PR message
+        id: pr_message
+        run: |
+          if [ "${{ inputs.package }}" == "" ]; then
+            echo "message=yarn create ${{ inputs.command }}" >> $GITHUB_OUTPUT
+          else
+            echo "message=${{ inputs.command }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create PR
         working-directory: ./repo
         env:
@@ -105,4 +136,4 @@ jobs:
           gh label create 'template/${{ inputs.name }}' -f -d 'Updates to ${{ inputs.name }} templates' -c ${{ inputs.color }}
           gh pr create -B ${{ github.event.repository.default_branch }} -H template/${{ inputs.name }} -l template/${{ inputs.name }} -t 'Updating ${{ inputs.name }} template(s)' -b ':robot: *An automated PR*
 
-          Generated template(s) with `yarn create ${{ inputs.command }}` in `./templates/${{ inputs.name }}`'
+          Generated template(s) with `${{ steps.pr_message.outputs.message }}` in `./templates/${{ inputs.name }}`'

--- a/.github/workflows/create-docusaurus-app.yml
+++ b/.github/workflows/create-docusaurus-app.yml
@@ -11,15 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         app:
-          - "{ type: 'classic', append: '-ts', flags: '--typescript' }"
-          - "{ type: 'classic', append: '-js', flags: '' }"
-          - "{ type: 'facebook', append: '-js', flags: '' }"
+          - "{ type: 'typescript', flags: '--typescript' }"
+          - "{ type: 'javascript', flags: '' }"
     uses: ./.github/workflows/create-app.yml
     with:
       name: docusaurus
       command: docusaurus
-      type: "${{ fromJson(matrix.app).type }}${{ fromJson(matrix.app).append }}"
-      flags: "${{ fromJson(matrix.app).type }} -s ${{ fromJson(matrix.app).flags }}"
+      type: ${{ fromJson(matrix.app).type }}
+      flags: "classic -s ${{ fromJson(matrix.app).flags }}"
       color: 3ECC5F
 
   sort_common_files:

--- a/.github/workflows/create-docusaurus-app.yml
+++ b/.github/workflows/create-docusaurus-app.yml
@@ -11,12 +11,19 @@ jobs:
       fail-fast: false
       matrix:
         app:
-          - "{ type: 'typescript', flags: '--typescript' }"
-          - "{ type: 'javascript', flags: '' }"
+          - "{ type: 'classic', append: '-ts', flags: '--typescript' }"
+          - "{ type: 'classic', append: '-js', flags: '' }"
+          - "{ type: 'facebook', append: '-js', flags: '' }"
     uses: ./.github/workflows/create-app.yml
     with:
       name: docusaurus
       command: docusaurus
-      type: ${{ fromJson(matrix.app).type }}
-      flags: "classic -s ${{ fromJson(matrix.app).flags }}"
+      type: "${{ fromJson(matrix.app).type }}${{ fromJson(matrix.app).append }}"
+      flags: "${{ fromJson(matrix.app).type }} -s ${{ fromJson(matrix.app).flags }}"
       color: 3ECC5F
+
+  sort_common_files:
+    needs: create_apps
+    uses: ./.github/workflows/sort-common-files.yml
+    with:
+      app: docusaurus

--- a/.github/workflows/create-next-app.yml
+++ b/.github/workflows/create-next-app.yml
@@ -20,3 +20,9 @@ jobs:
       type: ${{ fromJson(matrix.app).type }}
       flags: "--eslint ${{ fromJson(matrix.app).flags }}"
       color: "000000"
+
+  sort_common_files:
+    needs: create_apps
+    uses: ./.github/workflows/sort-common-files.yml
+    with:
+      app: next

--- a/.github/workflows/create-react-app.yml
+++ b/.github/workflows/create-react-app.yml
@@ -20,3 +20,9 @@ jobs:
       type: ${{ fromJson(matrix.app).type }}
       flags: "${{ fromJson(matrix.app).flags }}"
       color: 61dafb
+
+  sort_common_files:
+    needs: create_apps
+    uses: ./.github/workflows/sort-common-files.yml
+    with:
+      app: react

--- a/.github/workflows/create-redwood-app.yml
+++ b/.github/workflows/create-redwood-app.yml
@@ -20,3 +20,9 @@ jobs:
       type: ${{ fromJson(matrix.app).type }}
       flags: "--git false ${{ fromJson(matrix.app).flags }}"
       color: "bf4722"
+
+  sort_common_files:
+    needs: create_apps
+    uses: ./.github/workflows/sort-common-files.yml
+    with:
+      app: redwood

--- a/.github/workflows/create-remix-app.yml
+++ b/.github/workflows/create-remix-app.yml
@@ -30,3 +30,9 @@ jobs:
       type: "${{ matrix.template }}-${{ fromJson(matrix.app).type }}"
       flags: "--template ${{ matrix.template }} --no-install ${{ fromJson(matrix.app).flags }}"
       color: 3992ff
+
+  sort_common_files:
+    needs: create_apps
+    uses: ./.github/workflows/sort-common-files.yml
+    with:
+      app: remix

--- a/.github/workflows/sort-common-files.yml
+++ b/.github/workflows/sort-common-files.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-          path: repo
 
       - name: Setup node 18
         uses: actions/setup-node@v3
@@ -33,6 +32,7 @@ jobs:
 
       - name: Sort common files
         run: |
+          yarn
           yarn cfs ${{ inputs.app }}
 
         # create or switch to template branch
@@ -68,6 +68,8 @@ jobs:
           git push origin template/${{ inputs.app }}
 
       - name: Create PR
+        # an error here most likely means PR already exists, so we let it pass
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/sort-common-files.yml
+++ b/.github/workflows/sort-common-files.yml
@@ -1,0 +1,76 @@
+name: Sort Common Files
+on:
+  workflow_call:
+    inputs:
+      app:
+        required: true
+        description: "Type of app to sort common files (ex. 'react' or 'redwood')"
+        type: string
+  workflow_dispatch:
+    inputs:
+      app:
+        required: true
+        description: "Type of app to sort common files (ex. 'react' or 'redwood')"
+        type: string
+
+jobs:
+  sort_files:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          path: repo
+
+      - name: Setup node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Sort common files
+        run: |
+          yarn cfs ${{ inputs.app }}
+
+        # create or switch to template branch
+      - name: Switch to template branch
+        run: |
+          git config user.name "${{ inputs.app }}-app bot"
+          git config user.email "<>"
+          git config pull.rebase false
+          git switch -c template/${{ inputs.app }}
+
+      - name: Check for remote branch
+        id: remote_check
+        # failure handled in next step, so we let it pass
+        continue-on-error: true
+        run: |
+          git ls-remote --exit-code --heads origin template/${{ inputs.app }}
+
+        # pull or create remote branch
+      - name: Create or pull remote
+        run: |
+          if [ "${{ steps.remote_check.outcome }}" == "failure" ]; then
+            git push origin template/${{ inputs.app }}
+          else
+            git pull origin template/${{ inputs.app }}
+          fi
+
+      - name: Commit changes
+        # an error here most likely means no changes, so we let it pass
+        continue-on-error: true
+        run: |
+          git add ./templates/${{ inputs.app }}
+          git commit -m 'Update ${{ inputs.app }} common files '
+          git push origin template/${{ inputs.app }}
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create -B ${{ github.event.repository.default_branch }} -H template/${{ inputs.app }} -l template/${{ inputs.app }} -t 'Sort common files for ${{ inputs.app }} templates' -b ':robot: *An automated PR*
+
+          Sort common files in `./templates/${{ inputs.app }}`'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ example-app
 !.yarn/sdks
 !.yarn/versions
 yarn-error.log
+
+!templates/*
+*.tgz

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ yarn create jam <project-name> --app react
 yarn create jam <project-name> -a react
 ```
 
-If the app has a `javascript` template version it will automatically create that template.
-If there are multiple JavaScript templates, it will limit the template choices to just JavaScript options.
+This will skip directly to the template selection question.
 
 ### `--typescript | -ts`
 
@@ -62,7 +61,7 @@ To default to the TypeScript version, use the `--typescript` flag:
 ```bash
 yarn create jam <project-name> --app react --typescript
 # or
-yarn create jam <project-name> -a react -ts
+yarn create jam <project-name> -a react -t
 ```
 
 If the app has a `typescript` template version it will automatically create that template.
@@ -73,7 +72,7 @@ You can also provide the `--typescript` flag without the app type to utilize the
 ```bash
 yarn create jam <project-name> --typescript
 # or
-yarn create jam <project-name> -ts
+yarn create jam <project-name> -t
 ```
 
 ### `--overwrite | -o`

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "cmd": "rm -rf example-app && ts-node src/create-jam.ts example-app",
+    "cmd": "rm -rf example-app && ts-node src/create-jam.ts example-app -b",
+    "cfs": "node scripts/common-files.js",
     "test": "jest",
     "build": "rm -rf dist && tsc -p . && cp -r templates dist/templates"
   },
@@ -20,7 +21,6 @@
     "inquirer": "^8.2.3",
     "listr": "^0.14.3",
     "shelljs": "^0.8.5",
-    "slugify": "^1.6.5",
     "yargs": "^17.6.0"
   },
   "devDependencies": {

--- a/scripts/common-files.js
+++ b/scripts/common-files.js
@@ -1,0 +1,131 @@
+const fs = require('fs')
+const path = require('path')
+
+const template = process.argv[2]
+
+// Make sure an app template type is provided
+if (!template) throw new Error('No template provided')
+
+const dir = path.join(__dirname, '../templates', template)
+const commonFolder = path.join(dir, '_common')
+
+// App templates
+const subTemplates = fs
+  .readdirSync(dir, { withFileTypes: true })
+  .filter((t) => t.isDirectory() && t.name !== '_common')
+
+// No need to run this if only one template
+if (subTemplates.length === 1) process.exit(0)
+
+// Get list of all file paths in directory
+const getDirFiles = (directory, arr, splitDir) => {
+  fs.readdirSync(directory, { withFileTypes: true }).forEach((f) => {
+    const absolute = path.join(directory, f.name)
+
+    if (f.isDirectory()) return getDirFiles(absolute, arr, splitDir)
+
+    arr.push(absolute.split(`/templates/${template}/${splitDir}/`)[1])
+  })
+}
+
+// get dir files and return array of them
+const dirFiles = (directory, splitDir) => {
+  const arr = []
+
+  getDirFiles(directory, arr, splitDir)
+
+  return arr
+}
+
+// Files that have the same name
+let commonFiles = []
+
+// Find files with the same name
+for (let i = 0; i < subTemplates.length; i++) {
+  const subTemplate = subTemplates[i].name
+  const subTempPath = path.join(dir, subTemplate)
+
+  const files = dirFiles(subTempPath, subTemplate)
+
+  if (i === 0) {
+    commonFiles = files
+  } else {
+    commonFiles = commonFiles.filter((f) => files.indexOf(f) !== -1)
+  }
+}
+
+// Files that have the same name and content
+const commonContent = []
+
+// Find files with the same name and content
+if (commonFiles.length > 0) {
+  for (let i = 0; i < commonFiles.length; i++) {
+    const filePath = commonFiles[i]
+
+    const basePath = path.join(dir, subTemplates[0].name, filePath)
+
+    const otherTemplates = [...subTemplates]
+    otherTemplates.shift()
+
+    let same = true
+
+    for (let j = 0; j < otherTemplates.length; j++) {
+      if (!same) break
+
+      const subTemplateName = otherTemplates[j].name
+
+      const otherPath = path.join(dir, subTemplateName, filePath)
+
+      const baseContents = fs.readFileSync(basePath)
+      const otherContents = fs.readFileSync(otherPath)
+
+      if (!baseContents.equals(otherContents)) same = false
+    }
+
+    if (same) commonContent.push(filePath)
+  }
+}
+
+if (commonContent.length > 0) {
+  if (fs.existsSync(commonFolder)) {
+    fs.rmSync(commonFolder, { recursive: true, force: true })
+  }
+
+  fs.mkdirSync(commonFolder, { recursive: true })
+
+  const firstTemplate = path.join(dir, subTemplates[0].name)
+
+  // Copy common files to '_common' folder and remove from templates
+  for (let i = 0; i < commonContent.length; i++) {
+    const file = commonContent[i]
+
+    if (file === 'yarn.lock' && !commonContent.includes('package.json'))
+      continue
+
+    const fileTempPath = path.join(firstTemplate, file)
+    const newTempPath = path.join(commonFolder, file)
+
+    const subDirs = file.split('/')
+
+    if (subDirs.length > 1) {
+      subDirs.pop()
+
+      const subDirPath = path.join(commonFolder, subDirs.join('/'))
+
+      fs.mkdirSync(subDirPath, { recursive: true })
+    }
+
+    fs.copyFileSync(fileTempPath, newTempPath)
+
+    // Remove common files from templates
+    for (let j = 0; j < subTemplates.length; j++) {
+      const subTemplate = subTemplates[j].name
+
+      const fileToRemove = path.join(dir, subTemplate, file)
+
+      if (fs.existsSync(fileToRemove)) {
+        fs.rmSync(fileToRemove, { recursive: true, force: true })
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,7 +954,6 @@ __metadata:
     inquirer: ^8.2.3
     listr: ^0.14.3
     shelljs: ^0.8.5
-    slugify: ^1.6.5
     ts-node: ^10.9.1
     typescript: ^4.9.4
     yargs: ^17.6.0
@@ -3336,13 +3335,6 @@ __metadata:
   version: 0.0.4
   resolution: "slice-ansi@npm:0.0.4"
   checksum: 997d4cc73e34aa8c0f60bdb71701b16c062cc4acd7a95e3b10e8c05d790eb5e735d9b470270dc6f443b1ba21492db7ceb849d5c93011d1256061bf7ed7216c7a
-  languageName: node
-  linkType: hard
-
-"slugify@npm:^1.6.5":
-  version: 1.6.5
-  resolution: "slugify@npm:1.6.5"
-  checksum: 264059d9ea7aa95e472e66d19a1042ea54c75d3f60096c2cc57af4d66c6fb6ac1d8b4672326f276f52574fac489f59cb08848bfb97e44291c7e45211acb2b185
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a `sort-common-files` script which takes files that exist across all templates of a given app and compiles it into a `_common` folder. This reduces repeat code and brings down the bundled file size

Additionally, this allows for a CLI install in the `create-app` workflow, allowing fr app creation through respective app CLIs

## Motivation and Context
- Reduces package size and makes scaffolder more efficient
- Allows for more apps to be added

## How Has This Been Tested?
Ran script locally and tested GH workflows in separate repo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
