### PR TITLE
Add canary flag to tests and remove tests from compile

### DIFF
--- a/src/create-jam.test.ts
+++ b/src/create-jam.test.ts
@@ -57,6 +57,7 @@ describe('createJam', () => {
     writeFileSync(resolve(appDir, testFile), 'test')
 
     await createJam(appDir, 'react', {
+      canary: true,
       overwrite: true,
       template: 'typescript',
     })
@@ -76,6 +77,7 @@ describe('createJam', () => {
 
   it('should remove yarn.lock', async () => {
     await createJam(appDir, 'react', {
+      canary: true,
       template: 'typescript',
     })
 
@@ -84,6 +86,7 @@ describe('createJam', () => {
 
   it('should rename gitignore.template', async () => {
     await createJam(appDir, 'react', {
+      canary: true,
       template: 'typescript',
     })
 
@@ -130,6 +133,7 @@ describe('createJam', () => {
       )
 
       await createJam(destDir, t.app, {
+        canary: true,
         template: t.template,
       })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,10 +23,10 @@
     }
   },
   "include": [
-    "src/**/*"
+    "./src/**/*"
   ],
   "exclude": [
-    "templates"
+    "**/*.test.*"
   ],
   "ts-node": {
     "files": true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds the `canary` option to applicable tests
- Ensures test files don't get compiled during build

## Motivation and Context

- Prevents version errors when testing `createJam()` by using the `next` branch
- Removes unnecessary files from the built package

## How Has This Been Tested?
Ran locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
